### PR TITLE
Fix source location for pod spec

### DIFF
--- a/GZIP.podspec
+++ b/GZIP.podspec
@@ -3,9 +3,9 @@ Pod::Spec.new do |s|
   s.version      = '1.0'
   s.license      = 'MIT'
   s.summary      = 'GZip Compression / Decompression for NSData.'
-  s.homepage     = 'https://github.com/rcdilorenzo/GZIP'
+  s.homepage     = 'https://github.com/nicklockwood/GZIP'
   s.author       = { "Nick Lockwood" => "support@charcoaldesign.co.uk" }
-  s.source       = { :git => "https://github.com/rcdilorenzo/GZIP.git", :tag => "1.0" }
+  s.source       = { :git => "https://github.com/nicklockwood/GZIP.git", :tag => "1.0" }
   s.source_files = 'GZIP/NSData+GZIP.{h,m}'
   s.library      = 'z'
   s.platform     = :ios, '5.0'


### PR DESCRIPTION
@nicklockwood, I realized that I needed to fix the source URL in the `GZIP.podspec`. I hope you don't mind merging this **and then** following a couple instructions to get this added as a CocoaPod.

First of all, your 1.0 tag needs to be deleted and then recreated with this latest commit (which would be the merge commit of this pull-request), otherwise the podspec will not work. Here's how to do it if you've never done it before.

```
# cd into the GZIP directory and then run these commands
git tag -d 1.0
git push origin :refs/tags/1.0
```

After that, you'll need to go to [releases](https://github.com/nicklockwood/GZIP/releases) and create a new one with the tag name "1.0". Just let me know when you do it, I can add the `podspec` to the master CocoaPods repository.

If this doesn't make sense or you need help, just let me know.
