### PR TITLE
Add WatchOS 2 as a deployment target in podspec.

### DIFF
--- a/GZIP.podspec
+++ b/GZIP.podspec
@@ -10,4 +10,5 @@ Pod::Spec.new do |s|
   s.requires_arc = false
   s.ios.deployment_target = '4.3'
   s.osx.deployment_target = '10.6'
+  s.watchos.deployment_target = '2.0'
 end


### PR DESCRIPTION
Looks like the Xcode project already had a WatchOS target, so all I had to do was fork and update the pod spec.

Tested by using:

```
        pod 'GZIP', :git => 'https://github.com/ryanschneider/GZIP.git', :branch => 'podspec-watchos-target'
```

In my `Podfile`.
