### PR TITLE
In Xcode 9, Could not load module 'GZIP' error is caused.

### DIFF
--- a/GZIP/GZIP.h
+++ b/GZIP/GZIP.h
@@ -6,4 +6,4 @@ FOUNDATION_EXPORT double GZIPVersionNumber;
 //! Project version string for GZIP.
 FOUNDATION_EXPORT const unsigned char GZIPVersionString[];
 
-#import <GZIP/NSData+GZip.h>
+#import <GZIP/NSData+GZIP.h>


### PR DESCRIPTION
I suspected High Sierra or Xcode 9 at first.
I checked other environments as cocoapods, Xcode settings, and so on.
Finally I found different filename and header import as NSData+GZip.h in GZIP.h and NSData+GZIP.h file.