### PR TITLE
tvOS Support For Xcode 9

### DIFF
--- a/GZIP.xcodeproj/project.pbxproj
+++ b/GZIP.xcodeproj/project.pbxproj
@@ -422,7 +422,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.charcoaldesign.GZIP;
 				PRODUCT_NAME = GZIP;
-				SDKROOT = appletvos10.2;
+				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = 4;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
@@ -443,7 +443,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.charcoaldesign.GZIP;
 				PRODUCT_NAME = GZIP;
-				SDKROOT = appletvos10.2;
+				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = 4;
 				TVOS_DEPLOYMENT_TARGET = 9.0;


### PR DESCRIPTION
Problem:
When running carthage bootstrap,
error: There is no SDK with the name or path '/Users/dmiluski/Development/VenmoKit/Carthage/Checkouts/GZIP/appletvos10.2'

Why:
appletvos sdk root is hard coded to appletvos10.2 rather than to latest tvos. Which fails if I don't have that installed.

Solution:
Update tvos sdk root to reference generic latest.