### PR TITLE
Fix for issue with projects where modules are disabled

### DIFF
--- a/GZIP/GZIP.h
+++ b/GZIP/GZIP.h
@@ -1,4 +1,4 @@
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 //! Project version number for GZIP.
 FOUNDATION_EXPORT double GZIPVersionNumber;


### PR DESCRIPTION
We have a project with disabled modules. In case GZIP framework header is referenced from such code the compiler will throw an error like:

> GZIP/GZIP.framework/Headers/GZIP.h:1:1: error: use of '@import' when modules are disabled

I think supporting both modular and non-modular imports is beneficial.
