### PR TITLE
Add NSData+GZIP.m to watchOS/tvOS targets

### DIFF
--- a/GZIP.xcodeproj/project.pbxproj
+++ b/GZIP.xcodeproj/project.pbxproj
@@ -23,6 +23,8 @@
 		3AE36CD21B8F5AEF00923C2D /* NSData+GZIP.m in Sources */ = {isa = PBXBuildFile; fileRef = 3AE36CCB1B8F59E600923C2D /* NSData+GZIP.m */; };
 		3AE36CD51B8F5AEF00923C2D /* GZIP.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AE36CC21B8F598E00923C2D /* GZIP.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3AE36CD61B8F5AEF00923C2D /* NSData+GZIP.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AE36CCA1B8F59E600923C2D /* NSData+GZIP.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		ACE9FFBB23DF860500B3A145 /* NSData+GZIP.m in Sources */ = {isa = PBXBuildFile; fileRef = 3AE36CCB1B8F59E600923C2D /* NSData+GZIP.m */; };
+		ACE9FFBC23DF860600B3A145 /* NSData+GZIP.m in Sources */ = {isa = PBXBuildFile; fileRef = 3AE36CCB1B8F59E600923C2D /* NSData+GZIP.m */; };
 		C1BE0917228B5F77006800A0 /* NSData+SEGGZIP.m in Sources */ = {isa = PBXBuildFile; fileRef = C1BE0916228B5F77006800A0 /* NSData+SEGGZIP.m */; };
 /* End PBXBuildFile section */
 
@@ -369,6 +371,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				ACE9FFBB23DF860500B3A145 /* NSData+GZIP.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -385,6 +388,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				ACE9FFBC23DF860600B3A145 /* NSData+GZIP.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
When attempting to use GZIP in a watchOS app, the app will compile, but it crashes at runtime with an "unrecognized selector" exception. This PR fixes the crash — looks like the target membership checkbox just needed to be checked for the watchOS/tvOS targets.

I've tested this fix on watchOS simulator and real devices. Haven't tested with tvOS, but I presume it would run into the same problem so I made the same change for that platform.