### PR TITLE
GZIP.podspec: Bring back support for watchOS

### DIFF
--- a/GZIP.podspec
+++ b/GZIP.podspec
@@ -12,4 +12,5 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '11.0'
   s.osx.deployment_target = '10.13'
   s.tvos.deployment_target = '11.0'
+  s.watchos.deployment_target = '2.0'
 end


### PR DESCRIPTION
Looks like commit da881c9 removed support for watchOS in the `GZIP.podspec`.
I suppose this was not intentional and I would like to bring back watchOS support with this PR.